### PR TITLE
Atbd user guide updates

### DIFF
--- a/docs/atbd.md
+++ b/docs/atbd.md
@@ -115,8 +115,8 @@ The required input files for fractional cover production are in Table 4.3-1.
 
 ### 4.4 Fractional Cover Algorithm Output Variables
 The EMIT output data products delivered to the DAAC use their formatting conventions; the system operates internally on data products stored as binary data cubes with detached human-readable ASCII header files. For the fraction cover product, the output variables are: 
-1. Fractional cover, provided as an n x c x 3 BIL interleave data cube, with c columns and n lines. Each channel contains the fractional cover as calculated by E(MC)<sup>2</sup> (see section 4.2.1). The band order is PV fractional cover (band 1), NPV fractional cover (band 2), and soil fractional cover (band 3).
-2. Fractional cover uncertainty, provided as an n x c x 3 BIL interleave data cube, with c columns and n lines. Each channel contains the estimated uncertainty of the fraction cover, as defined in section 6.2. The band order is PV fractional cover uncertainty (Band 1), NPV fractional cover uncertainty (band 2), and soil fractional cover uncertainty (band 3).
+1. Fractional cover, provided as an n x c x 3 BIL interleave data cube, with c columns and n lines. Each channel contains the fractional cover as calculated by E(MC)<sup>2</sup> (see section 4.2.1). The band order is NPV fractional cover (band 1), PV fractional cover (band 2), and soil fractional cover (band 3).
+2. Fractional cover uncertainty, provided as an n x c x 3 BIL interleave data cube, with c columns and n lines. Each channel contains the estimated uncertainty of the fraction cover, as defined in section 6.2. The band order is NPV fractional cover uncertainty (Band 1), PV fractional cover uncertainty (band 2), and soil fractional cover uncertainty (band 3).
 
 These products are consistent with the auxiliary data products described in the EMIT L3ASA ATBD, section 4.4.2 (Brodrick et al., 2023).
 

--- a/docs/atbd.md
+++ b/docs/atbd.md
@@ -109,9 +109,9 @@ The required input files for fractional cover production are in Table 4.3-1.
 
 | Name | Description | Unit | Required |
 | --- | --- | --- | --- |
-| HDRF (Surface Reflectance) | hemispherical-directional reflectance factor per wavelength | unitless | true |
+| EMIT L2A Surface Reflectance | hemispherical-directional reflectance factor per wavelength | unitless | true |
+| EMIT L2A Surface Reflectance Uncertainty | hemispherical-directional reflectance uncertainty per wavelength | unitless | true |
 | Endmember Spectral Library | collection of spectral surface endmembers (HDRF per wavelength) | unitless | true |
-| Observation Geometry | solar zenith angle, view zenith angle, relative azimuth angle | degree | false |
 
 ### 4.4 Fractional Cover Algorithm Output Variables
 The EMIT output data products delivered to the DAAC use their formatting conventions; the system operates internally on data products stored as binary data cubes with detached human-readable ASCII header files. For the fraction cover product, the output variables are: 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -36,7 +36,7 @@ Table 1 1: EMITL2BFRCOV collection file list and naming convention
 | EMIT_L2B_FRCOVPVUNC_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.tif  | Fractional Cover Uncertainty, Photosynthetic Vegetation (aerial fraction) |
 | EMIT_L2B_FRCOVNPVUNC_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.tif  | Fractional Cover Uncertainty, Non-Photosynthetic Vegetation (aerial fraction) |  
 | EMIT_L2B_FRCOVBAREUNC_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.tif  | Fractional Cover Uncertainty, Bare Soil (aerial fraction) |
-| EMIT_L2B_FRCOVQC_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.nc  | QC Flag Bands (integer)|
+| EMIT_L2B_FRCOVQC_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.tif  | QC Flag Bands (integer)|
 | EMIT_L2B_FRCOV_&lt;VVV&gt;_&lt;YYYYMMDDTHHMMSS&gt;_&lt;OOOOO&gt;_&lt;SSS&gt;.png  | Browse |
 
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -50,7 +50,7 @@ Table 1 1: EMITL2BFRCOV collection file list and naming convention
 &lt;SSS&gt; is the scene identification number, e.g., 007
 
 ##### 1.3.2    L2BFRCOV Data Products
-The EMIT L2B Fractional Cover collection contains estimated surface fractional cover and quality assurance bands as Cloud Optimized GeoTIFF (COG) files. Each COG file contains multiple bands and the data are organized in a way that allows for efficient access and retrieval of specific bands or subsets of the data.
+The EMIT L2B Fractional Cover collection contains estimated surface fractional cover and quality assurance bands as Cloud Optimized GeoTIFF (COG) files, which are organized to allow efficient access and retrieval of data subsets.
 
 #### 1.4 Product Availability
 The EMIT L2BFRCOV products will be available at the NASA Land Processes Distributed Active Archive Center (LP DAAC, https://lpdaac.usgs.gov/) and through NASA Earthdata (https://earthdata.nasa.gov/).


### PR DESCRIPTION
- Change QC Flag Bands file extension from .nc to .tif
- Revise fractional cover output variable order
- Remove reference to multiple bands in COG file description
- Updated fractional cover algorithm inputs